### PR TITLE
Selection of the affine parameters in "my_ants_affine_to_distance"

### DIFF
--- a/MotionCorrection/my_ants_affine_to_distance.py
+++ b/MotionCorrection/my_ants_affine_to_distance.py
@@ -25,7 +25,7 @@ def my_ants_affine_to_distance(affine, unit):
     
     rot_y = np.arcsin(affine[2])
     cos_rot_y = np.cos(rot_y)
-    rot_x = np.arctan2(affine[8] / cos_rot_y, affine[8] / cos_rot_y)
+    rot_x = np.arctan2(affine[4] / cos_rot_y, affine[8] / cos_rot_y)
     rot_z = np.arctan2(affine[2] / cos_rot_y, affine[0] / cos_rot_y)
 
     if unit == 'deg':

--- a/MotionCorrection/my_ants_affine_to_distance.py
+++ b/MotionCorrection/my_ants_affine_to_distance.py
@@ -20,6 +20,9 @@ def my_ants_affine_to_distance(affine, unit):
     #the first 9 elementes are stored in row major order. This is the same
     #order used in C/C++ and Python (while R and MATLAB follow colmajor order)
     
+    #See "Rigid Body Registration" (John Ashburner & Karl J. Friston) to have 
+    #an explanation of how to select the parameters in the rotation matrix
+    
     rot_y = np.arcsin(affine[2])
     cos_rot_y = np.cos(rot_y)
     rot_x = np.arctan2(affine[8] / cos_rot_y, affine[8] / cos_rot_y)

--- a/MotionCorrection/my_ants_affine_to_distance.py
+++ b/MotionCorrection/my_ants_affine_to_distance.py
@@ -25,7 +25,7 @@ def my_ants_affine_to_distance(affine, unit):
     
     rot_y = np.arcsin(affine[2])
     cos_rot_y = np.cos(rot_y)
-    rot_x = np.arctan2(affine[4] / cos_rot_y, affine[8] / cos_rot_y)
+    rot_x = np.arctan2(affine[5] / cos_rot_y, affine[8] / cos_rot_y)
     rot_z = np.arctan2(affine[2] / cos_rot_y, affine[0] / cos_rot_y)
 
     if unit == 'deg':

--- a/MotionCorrection/my_ants_affine_to_distance.py
+++ b/MotionCorrection/my_ants_affine_to_distance.py
@@ -15,11 +15,15 @@ import numpy as np
 def my_ants_affine_to_distance(affine, unit):
 
     dx, dy, dz = affine[9:]
-
-    rot_x = np.arcsin(affine[6])
-    cos_rot_x = np.cos(rot_x)
-    rot_y = np.arctan2(affine[7] / cos_rot_x, affine[8] / cos_rot_x)
-    rot_z = np.arctan2(affine[3] / cos_rot_x, affine[0] / cos_rot_x)
+    
+    #according to https://itk.org/Doxygen/html/classitk_1_1AffineTransform.html
+    #the first 9 elementes are stored in row major order. This is the same
+    #order used in C/C++ and Python (while R and MATLAB follow colmajor order)
+    
+    rot_y = np.arcsin(affine[2])
+    cos_rot_y = np.cos(rot_y)
+    rot_x = np.arctan2(affine[8] / cos_rot_y, affine[8] / cos_rot_y)
+    rot_z = np.arctan2(affine[2] / cos_rot_y, affine[0] / cos_rot_y)
 
     if unit == 'deg':
         deg = np.degrees


### PR DESCRIPTION
ANTS is based on ITK package and this is true also for ANTsPy. When performing the rigid alignment ITK return 12 parameters: the first 9 parameters indicate scaling, rotation and shearing and are stored in row-major order (https://itk.org/Doxygen/html/classitk_1_1AffineTransform.html); the last 3 parameters indicates the translation along (hopefully) x, y, and z axis. 

Therefore when estimating the six motion parameters according to https://www.fil.ion.ucl.ac.uk/spm/doc/books/hbf2/pdfs/Ch2.pdf we need to consider how the first 9 parameters can be placed in the following 3x3 matrix: 
`[[0,1,2],
  [3,4,5],
  [6,7,8]]` 

Following the formulas by Ashburner and Friston we have that q1, q2 and q3 corresponds to the translation parameters and the remaining rotation parameters q4, q5, q6 are estimated as follows:
`q5 = asin(r13)` 
`q4 = atan2(r23/cos(q5), r33/cos(q5)` 
`q6 = atan2(r12/cos(q5), r11/cos(q5)` 
The parameter q5 should be rotation around y `rot_y`, q4 the one around x and q6 around z. 

This will end up in the new code and possibly in a correct estimation of the motion parameters: 
`rot_y = np.arcsin(affine[2])` 
`cos_rot_y = np.cos(rot_y)` 
`rot_x = np.arctan2(affine[5] / cos_rot_y, affine[8] / cos_rot_y)` 
`rot_z = np.arctan2(affine[1] / cos_rot_y, affine[0] / cos_rot_y)` 
